### PR TITLE
annotating the synopsis with homdels of TSGs and amps of oncogenes.

### DIFF
--- a/report.rmd
+++ b/report.rmd
@@ -115,6 +115,10 @@ WGS-based estimation of TMB (number per Mb): `r out[track=="tmb" & type=="densit
  
 WGS-based estimation of junction burden: `r length(gg$junctions[type=="ALT"])`
 
+Oncogenes with copy number amplifications: `r get_oncogenes_with_amp(out)`
+
+Ttumor suppressor genes with homozygous deletions: `r get_TSG_with_homdels(out)`
+
 *** 
 # SV overview {.tabset .tabset-fade .tabset-pills}
 ```{r, overview, message = FALSE, echo = FALSE, results = "asis", out.width = "100%"}

--- a/utils.R
+++ b/utils.R
@@ -527,3 +527,35 @@ circos = function(junctions = jJ(), cov = NULL, ncov = NULL, segs = NULL, win = 
     }
     circlize::circos.clear()
 }
+
+
+get_oncogenes_with_amp = function(oncotable){
+    amplified_oncogenes = oncotable[grepl('ONC', role)][type == 'amp']
+    strout = 'There are no oncogenes with copy number amplifications.'
+    if (amplified_oncogenes[, .N] > 0){
+        # TODO: we can later add the CN for each of these genes
+        strout = paste0(paste(unique(amplified_oncogenes$gene), collapse = ', '), '.')
+    }
+    return(strout)
+}
+
+get_TSG_with_homdels = function(oncotable){
+    homdel_tsgs = oncotable[grepl('TSG', role)][type == 'homdel']
+    strout = 'There are no tumor suppressor genes with homozygous deletions.'
+    if (homdel_tsgs[, .N] > 0){
+        # TODO: we can later add the CN for each of these genes
+        strout = paste0(paste(unique(homdel_tsgs$gene), collapse = ', '), '.')
+    }
+    return(strout)
+}
+
+check_file = function(fn, overwrite = FALSE, verbose = TRUE){
+    if (file.exists(fn) & file.size(fn) > 0 & !overwrite){
+        if (verbose){
+            message('Found ', fn, ' so reading it. If you wish to regenerate, please repeat with "overwrite = TRUE".')
+        }
+        return(TRUE)
+    }
+        return(FALSE)
+}
+


### PR DESCRIPTION
In addition, changed to use the skitools function for calling gene amps and dels since the previous implementation did not consider the minimal CN of a gene and hence a gene could be annotated with both dels and amps. Lastly, this commit includes changes to check for the existance of files that are written to the disk so that if they exist (and overwrite == FALSE) then they will be used instead of regenerated.